### PR TITLE
Move sensor and version to attributes instead of hardcoding them.

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -19,7 +19,7 @@ license that can be found in the LICENSE file.
 
 <link rel="import" href="../polymer/polymer.html">
 
-<polymer-element name="google-map" attributes="latitude longitude zoom showCenterMarker map">
+<polymer-element name="google-map" attributes="latitude longitude zoom showCenterMarker version sensor map">
   <template>
     <style>
       :host {
@@ -40,11 +40,11 @@ license that can be found in the LICENSE file.
   <script>
     (function() {
       var CALLBACK_NAME = 'polymer_google_map_callback';
-      var MAP_URL = 'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&sensor=false&callback=' + CALLBACK_NAME;
+      var MAP_URL = 'https://maps.googleapis.com/maps/api/js?libraries=places&callback=' + CALLBACK_NAME;
       var pendingCallbacks = [];
       var loading;
       
-      function loadMapApi(callback) {
+      function loadMapApi(callback, version, sensor) {
         if (window.google && window.google.maps) {
           callback();
           return;
@@ -53,7 +53,7 @@ license that can be found in the LICENSE file.
           loading = true;
           window[CALLBACK_NAME] = mapApiLoaded.bind(this);
           var s = document.createElement('script');
-          s.src = MAP_URL;
+          s.src = MAP_URL + '&v=' + version + '&sensor=' + sensor;
           document.head.appendChild(s);
         }
         pendingCallbacks.push(callback);
@@ -71,12 +71,14 @@ license that can be found in the LICENSE file.
         longitude: '-122.41942',
         zoom: 10,
         showCenterMarker: false,
+        version: '3.exp',
+        sensor: false,
         observe: {
           latitude: 'updateCenter',
           longitude: 'updateCenter'
         },
         ready: function() {
-          loadMapApi(this.mapReady.bind(this));
+          loadMapApi(this.mapReady.bind(this), this.version, this.sensor);
         },
         enteredView: function() {
           this.resize();


### PR DESCRIPTION
Users may need to indicate they are using a sensor, or load a different version of the API.
