### PR TITLE
Fixes #8 - point to correct dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "google-map",
   "private": true,
   "dependencies": {
-    "google-apis": "Polymer/google-apis#master"
+    "google-apis": "PolymerLabs/google-apis#master"
   }
 }


### PR DESCRIPTION
We currently point to `Polymer/google-apis` rather than it's current location in `PolymerLabs`. This PR fixes that.
