### PR TITLE
Stop geocoding (start,end) address before finding directions.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <img src="http://upload.wikimedia.org/wikipedia/commons/thumb/4/49/San_Francisco_Giants_Cap_Insignia.svg/200px-San_Francisco_Giants_Cap_Insignia.svg.png" />
       </google-map-marker>
     </google-map>
-    <google-map-directions startLocation="San Francisco" endLocation="Mountain View"></google-map-directions>
+    <google-map-directions startAddress="San Francisco" endAddress="Mountain View"></google-map-directions>
 
     <script>
       var gmap = document.querySelector('google-map');

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
-<polymer-element name="google-map-directions" attributes="map startLocation endLocation travelMode response">
+<polymer-element name="google-map-directions" attributes="map startAddress endAddress travelMode response">
   <template>
     <style>
       :host {
@@ -21,13 +21,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer('google-map-directions', {
       // google.maps.Map instance
       map: null,
-      startLocation: null,
-      endLocation: null,
+      startAddress: null,
+      endAddress: null,
       // DRIVING, WALKING, BICYCLING, TRANSIT
       travelMode: 'DRIVING',
       observe: {
-        startLocation: 'route',
-        endLocation: 'route',
+        startAddress: 'route',
+        endAddress: 'route',
         travelMode: 'route'
       },
       mapChanged: function() {
@@ -42,12 +42,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.route();
       },
       route: function() {
-        if (!this.map || !this.startLocation || !this.endLocation) {
+        if (!this.map || !this.startAddress || !this.endAddress) {
           return;
         }
         var request = {
-          origin: this.startLocation,
-          destination: this.endLocation,
+          origin: this.startAddress,
+          destination: this.endAddress,
           optimizeWaypoints: true,
           travelMode: this.travelMode
         };


### PR DESCRIPTION
There is no need to geocode an address first, the DirectionsService will do that automatically.
This saves 2 geocoder calls and the overhead of loading the module.
