### PR TITLE
Allow google-map-directions to work without a map, close #15.

### DIFF
--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -36,8 +36,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.route();
       },
       responseChanged: function() {
-        if (this.directionsRenderer) {
-          this.directionsRenderer.setDirections(response);
+        if (this.directionsRenderer && this.response) {
+          this.directionsRenderer.setDirections(this.response);
         }
       },
       mapChanged: function() {
@@ -46,10 +46,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.directionsRenderer = new google.maps.DirectionsRenderer();
           }
           this.directionsRenderer.setMap(this.map);
-          responseChanged();
+          this.responseChanged();
         } else {
           // If there is no more map, remove the directionsRenderer from the map and delete it.
-          this.directionsRenderer.setMap();
+          this.directionsRenderer.setMap(null);
           this.directionsRenderer = null;
         }
       },
@@ -73,6 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.directionsService.route(request, function(response, status) {
           if (status == google.maps.DirectionsStatus.OK) {
             this.response = response;
+            this.fire('google-map-response', {response: response});
           }
         }.bind(this));
       }


### PR DESCRIPTION
- Include google-apis to load the Maps API directly instead of relying on the map.
- Only use a `DirectionsRenderer` when a map exists.

Demo I used for testing: https://gist.github.com/bamnet/c20be84547af83433fd8.
