### PR TITLE
Extracted `mapOptions` from `mapApiLoaded`

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -250,6 +250,23 @@ The `google-map` element renders a Google Map.
         startAddress="San Francisco" endAddress="Mountain View">
     </google-map-directions>
 
+<b>Example</b> - not all map options are included as attributes out of the box.
+To add custom map options, you can extend this element:
+
+    <polymer-element name="my-google-map" extends="google-map">
+      <script>
+        Polymer('my-google-map', {
+
+          getMapOptions: function() {
+            var mapOptions = this.super();
+            mapOptions["streetViewControl"] = false;
+            return mapOptions;
+          }
+
+        });
+      </script>
+    </polymer-element>
+
 @element google-map
 @homepage github.io
 @blurb Element wrapper around Google Maps API.


### PR DESCRIPTION
This makes it easier to change the options when extending google-maps;

I imagine there are plans to add more map options as attributes to this component, but in the meantime, it might be useful to allow people to simply extend this element and add additional options easily, for example:

```
<polymer-element name="my-google-map" extends="google-map">
...
Polymer('my-google-map', {
  getMapOptions: function() {
    var mapOptions = this.super();
    mapOptions["streetViewControl"] = false;
    return mapOptions;
  }
});
</polymer-element>
```

I apologize for the clutter in the commit. The atom editor automatically cleaned up any empty indents. I'd be happy to re-do the pull-request if you want...
