### PR TITLE
Fix updateCenter on first centering, close #32.

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -426,6 +426,9 @@ Fired when the Maps API has fully loaded.
     updateMarkers: function() {
       this.markers = Array.prototype.slice.call(
           this.$.markers.getDistributedNodes());
+      if (this.centerMarker) {
+        this.markers.push(this.centerMarker);
+      }
       
       this.onMutation(this, this.updateMarkers); // Watch for future updates.
 
@@ -492,15 +495,21 @@ Fired when the Maps API has fully loaded.
       if (!this.map) {
         return;
       }
-      if (!this.centerMarker && this.showCenterMarker) {
-        this.centerMarker = new google.maps.Marker({
-          map: this.map
-        });
+      if (this.showCenterMarker) {
+        if (!this.centerMarker) {
+          this.centerMarker = document.createElement('google-map-marker');
+        }
+        var center = this.map.getCenter();
+        this.centerMarker.latitude = center.lat();
+        this.centerMarker.longitude = center.lng();
+      } else {
+        if (this.centerMarker) {
+          //TODO(bamnet): Clean up markers so they can be removed easier from a map.
+          this.centerMarker.marker.setMap(null);
+          this.centerMarker = null;
+        }
       }
-      if (this.centerMarker) {
-        this.centerMarker.setPosition(this.map.getCenter());
-        this.centerMarker.setMap(this.showCenterMarker ? this.map : null);
-      }
+      this.updateMarkers();
     },
     
     disableDefaultUIChanged: function() {


### PR DESCRIPTION
panTo() doesn't set the center immediately which results in:
1. showCenterMarker not knowing where the center is.
2. fitToMarkers setCenter is overridden by the panTo completion.
