### PR TITLE
Fixes #52: Only update if lat/long are a numeric type

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -520,11 +520,9 @@ Fired when the Maps API has fully loaded.
     updateCenter: function() {
       if (!this.map) {
         return;
-      }
-      else if (typeof this.latitude !== 'number' || isNaN(this.latitude)) {
+      } else if (typeof this.latitude !== 'number' || isNaN(this.latitude)) {
         throw new TypeError('latitude must be a number');
-      }
-      else if (typeof this.longitude !== 'number' || isNaN(this.longitude)) {
+      } else if (typeof this.longitude !== 'number' || isNaN(this.longitude)) {
         throw new TypeError('longitude must be a number');
       }
 


### PR DESCRIPTION
Map center is only updated if `latitude` and `longitude` are of type `Number`.
