### PR TITLE
Zooming in/out the map updates zoom value. Fixes #59.

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -546,7 +546,7 @@ Fired when the Maps API has fully loaded.
     },
 
     zoomChanged: function() {
-      if (this.map && this.map.getZoom() !== this.zoom) {
+      if (this.map) {
         this.map.setZoom(Number(this.zoom));
       }
     },


### PR DESCRIPTION
Listen for `zoom_changed` events and update the map zoom level if new value is not equal to the old value.
