### PR TITLE
Moves updateMarkers inside showCenterMarkerChanged() into a conditional

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -611,7 +611,9 @@ Fired when the Maps API has fully loaded.
           this.centerMarker = null;
         }
       }
-      this.updateMarkers();
+      if (this.centerMarker) {
+        this.updateMarkers();
+      }
     },
 
     disableDefaultUIChanged: function() {


### PR DESCRIPTION
This is to prevent unnecessary calls to updateMarkers when dragging the map. Only triggers when showCenterMarker is true. This fixes #69, albeit incompletely. This will still fail if showCenterMarker is true.