### PR TITLE
Adding display: block

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -294,6 +294,7 @@ Fired when the Maps API has fully loaded.
   <style>
 
     :host {
+      display: block;
       position: relative;
     }
 


### PR DESCRIPTION
Adding display: block to :host, since by default the content has no width or height thus doesn't render given the default display: inline.
