### PR TITLE
display:block and fill to respect div fixes #73

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -224,7 +224,6 @@ The `google-map` element renders a Google Map.
 
     <style>
       google-map {
-        display: block;
         height: 600px;
       }
     </style>
@@ -295,6 +294,8 @@ Fired when the Maps API has fully loaded.
 
     :host {
       position: relative;
+      display: block;
+      height: 100%;
     }
 
     #map {


### PR DESCRIPTION
By default makes google-map display: block
It autofills the div that it is in.
