### PR TITLE
Allows a preferred language to be specified fixes issue #77

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -609,7 +609,7 @@ Fired when the Maps API has fully loaded.
      * The localized language to load the Maps API with. For more information
      * see https://developers.google.com/maps/documentation/javascript/basics#Language
      *
-     * Note: the Maps API defaults to the preffered language setting of the browser.
+     * Note: the Maps API defaults to the preferred language setting of the browser.
      * Use this parameter to override that behavior. 
      *
      * @attribute language

--- a/google-map.html
+++ b/google-map.html
@@ -419,10 +419,14 @@ Fired when the Maps API has fully loaded.
 - Use <google-maps-api>.api instead of google.maps namespace.
 -->
 <<<<<<< HEAD
+<<<<<<< HEAD
 <polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn">
 =======
 <polymer-element name="google-map" attributes="apiKey latitude longitude zoom showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries language">
 >>>>>>> f837dc2... Allows a preferred language to be specified
+=======
+<polymer-element name="google-map" attributes="apiKey latitude longitude zoom showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn language">
+>>>>>>> 611456b... Fixed spacing
 <template>
 
   <style>
@@ -443,11 +447,7 @@ Fired when the Maps API has fully loaded.
 
   </style>
 
-<<<<<<< HEAD
-  <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}" signedIn="{{signedIn}}"></google-maps-api>
-=======
-  <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}" language="{{language}}"></google-maps-api>
->>>>>>> f837dc2... Allows a preferred language to be specified
+  <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}" signedIn="{{signedIn}}" language="{{language}}"></google-maps-api>
 
   <div id="map"></div>
 
@@ -610,7 +610,7 @@ Fired when the Maps API has fully loaded.
      * see https://developers.google.com/maps/documentation/javascript/basics#Language
      *
      * Note: the Maps API defaults to the preferred language setting of the browser.
-     * Use this parameter to override that behavior. 
+     * Use this parameter to override that behavior.
      *
      * @attribute language
      * @type string

--- a/google-map.html
+++ b/google-map.html
@@ -418,15 +418,8 @@ Fired when the Maps API has fully loaded.
 - Handle removals and support .innerHTML = ''.
 - Use <google-maps-api>.api instead of google.maps namespace.
 -->
-<<<<<<< HEAD
-<<<<<<< HEAD
-<polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn">
-=======
-<polymer-element name="google-map" attributes="apiKey latitude longitude zoom showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries language">
->>>>>>> f837dc2... Allows a preferred language to be specified
-=======
-<polymer-element name="google-map" attributes="apiKey latitude longitude zoom showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn language">
->>>>>>> 611456b... Fixed spacing
+
+<polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn language">
 <template>
 
   <style>

--- a/google-map.html
+++ b/google-map.html
@@ -418,7 +418,11 @@ Fired when the Maps API has fully loaded.
 - Handle removals and support .innerHTML = ''.
 - Use <google-maps-api>.api instead of google.maps namespace.
 -->
+<<<<<<< HEAD
 <polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn">
+=======
+<polymer-element name="google-map" attributes="apiKey latitude longitude zoom showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries language">
+>>>>>>> f837dc2... Allows a preferred language to be specified
 <template>
 
   <style>
@@ -439,7 +443,11 @@ Fired when the Maps API has fully loaded.
 
   </style>
 
+<<<<<<< HEAD
   <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}" signedIn="{{signedIn}}"></google-maps-api>
+=======
+  <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}" language="{{language}}"></google-maps-api>
+>>>>>>> f837dc2... Allows a preferred language to be specified
 
   <div id="map"></div>
 
@@ -596,6 +604,19 @@ Fired when the Maps API has fully loaded.
      * @default false
      */
     signedIn: false,
+
+    /**
+     * The localized language to load the Maps API with. For more information
+     * see https://developers.google.com/maps/documentation/javascript/basics#Language
+     *
+     * Note: the Maps API defaults to the preffered language setting of the browser.
+     * Use this parameter to override that behavior. 
+     *
+     * @attribute language
+     * @type string
+     * @default null
+     */
+    language: null,
 
     observe: {
       latitude: 'updateCenter',


### PR DESCRIPTION
Passes  language through to the google-maps-api and allows people to specify a language to display the map in.