### PR TITLE
Trims infowindow content

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -143,7 +143,7 @@ child of `google-map`.
       contentChanged: function() {
         this.onMutation(this, this.contentChanged); // Watch for future updates.
 
-        var content = this.innerHTML;
+        var content = this.innerHTML.trim();
         if (content) {
           if (!this.info) {
             // Create a new infowindow

--- a/test/marker-basic.html
+++ b/test/marker-basic.html
@@ -20,7 +20,7 @@ var map = document.querySelector('#map1');
 
 suite('markers', function() {
 
-  // TODO: add test for info window content.
+  // TODO: add test for info window content, including empty & whitespace-only.
   test('infowindow', function() {
   });
   test.skip('infowindow');


### PR DESCRIPTION
This fix prevents an empty infowindow from appearing when there is only whitespace between a google-map-marker's open and close tags.