### PR TITLE
Fix map marker icon docs

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -78,7 +78,7 @@ child of `google-map`.
        * Image URL for the marker icon.
        *
        * @attribute icon
-       * @type string
+       * @type string|google.maps.Icon|google.maps.Symbol
        * @default null
        */
       icon: null,


### PR DESCRIPTION
This updates the type documentation for the google-map-marker components's icon property to match the official documentation (see https://developers.google.com/maps/documentation/javascript/reference#MarkerOptions).