### PR TITLE
Fire events for a map's mouse/touch and lifecycle events

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -673,7 +673,7 @@ Fired when the Maps API has fully loaded.
       }
     },
 
-    addEventForwarder: function(name) {
+    _addEventForwarder: function(name) {
       google.maps.event.addListener(this.map, name, function(event) {
         this.fire('google-map-' + name, event);
       }.bind(this));
@@ -690,18 +690,18 @@ Fired when the Maps API has fully loaded.
         this.zoom = this.map.getZoom();
       }.bind(this));
 
-      this.addEventForwarder('click');
-      this.addEventForwarder('dblclick');
-      this.addEventForwarder('drag');
-      this.addEventForwarder('dragend');
-      this.addEventForwarder('dragstart');
-      this.addEventForwarder('idle');
-      this.addEventForwarder('mousemove');
-      this.addEventForwarder('mouseout');
-      this.addEventForwarder('mouseover');
-      this.addEventForwarder('projection-changed');
-      this.addEventForwarder('rightclick');
-      this.addEventForwarder('tiles-loaded');
+      this._addEventForwarder('click');
+      this._addEventForwarder('dblclick');
+      this._addEventForwarder('drag');
+      this._addEventForwarder('dragend');
+      this._addEventForwarder('dragstart');
+      this._addEventForwarder('idle');
+      this._addEventForwarder('mousemove');
+      this._addEventForwarder('mouseout');
+      this._addEventForwarder('mouseover');
+      this._addEventForwarder('projection-changed');
+      this._addEventForwarder('rightclick');
+      this._addEventForwarder('tiles-loaded');
     }
 
   });

--- a/google-map.html
+++ b/google-map.html
@@ -64,7 +64,7 @@ be true.
 -->
 
 <!--
-Fired  when the mouse leaves the area of the marker icon. Requires the mouseEvents attribute to be
+Fired when the mouse leaves the area of the marker icon. Requires the mouseEvents attribute to be
 true.
 
 @event google-map-marker-mouseout
@@ -413,12 +413,67 @@ Fired when the Maps API has fully loaded.
 
 @event google-map-ready
 -->
+<!--
+Fired when the when the user clicks on the map (but not when they click on a marker, infowindow, or
+other object). Requires the clickEvents attribute to be true.
+
+@event google-map-click
+@param {google.maps.MouseEvent} event The mouse event.
+-->
+<!--
+Fired when the user double-clicks on the map. Note that the google-map-click event will also fire,
+right before this one. Requires the clickEvents attribute to be true.
+
+@event google-map-dblclick
+@param {google.maps.MouseEvent} event The mouse event.
+-->
+<!--
+Fired repeatedly while the user drags the map. Requires the dragEvents attribute to be true.
+
+@event google-map-drag
+-->
+<!--
+Fired when the user stops dragging the map. Requires the dragEvents attribute to be true.
+
+@event google-map-dragend
+-->
+<!--
+Fired when the user starts dragging the map. Requires the dragEvents attribute to be true.
+
+@event google-map-dragstart
+-->
+<!--
+Fired whenever the user's mouse moves over the map container. Requires the mouseEvents attribute to
+be true.
+
+@event google-map-mousemove
+@param {google.maps.MouseEvent} event The mouse event.
+-->
+<!--
+Fired when the user's mouse exits the map container. Requires the mouseEvents attribute to be true.
+
+@event google-map-mouseout
+@param {google.maps.MouseEvent} event The mouse event.
+-->
+<!--
+Fired when the user's mouse enters the map container. Requires the mouseEvents attribute to be true.
+
+@event google-map-mouseover
+@param {google.maps.MouseEvent} event The mouse event.
+-->
+<!--
+Fired when the DOM `contextmenu` event is fired on the map container. Requires the clickEvents
+attribute to be true.
+
+@event google-map-rightclick
+@param {google.maps.MouseEvent} event The mouse event.
+-->
 
 <!-- TODO(ericbidelman):
 - Handle removals and support .innerHTML = ''.
 - Use <google-maps-api>.api instead of google.maps namespace.
 -->
-<polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn">
+<polymer-element name="google-map" attributes="apiKey latitude longitude zoom noAutoTilt showCenterMarker version map mapType disableDefaultUI fitToMarkers zoomable styles maxZoom minZoom libraries signedIn clickEvents dragEvents mouseEvents">
 <template>
 
   <style>
@@ -597,6 +652,33 @@ Fired when the Maps API has fully loaded.
      */
     signedIn: false,
 
+    /**
+     * When true, map *click events are automatically registered.
+     *
+     * @attribute clickEvents
+     * @type boolean
+     * @default false
+     */
+    clickEvents: false,
+
+    /**
+     * When true, map drag* events are automatically registered.
+     *
+     * @attribute dragEvents
+     * @type boolean
+     * @default false
+     */
+    dragEvents: false,
+
+    /**
+     * When true, map mouse* events are automatically registered.
+     *
+     * @attribute mouseEvents
+     * @type boolean
+     * @default false
+     */
+    mouseEvents: false,
+
     observe: {
       latitude: 'updateCenter',
       longitude: 'updateCenter'
@@ -613,6 +695,7 @@ Fired when the Maps API has fully loaded.
     mapApiLoaded: function() {
       this.map = new google.maps.Map(this.$.map, this.getMapOptions());
 
+      this._listeners = {};
       this.updateCenter();
       this.updateMarkers();
       this.addMapListeners();
@@ -727,6 +810,48 @@ Fired when the Maps API has fully loaded.
       }
     },
 
+    clickEventsChanged: function() {
+      if (this.map) {
+        if (this.clickEvents) {
+          this._forwardEvent('click');
+          this._forwardEvent('dblclick');
+          this._forwardEvent('rightclick');
+        } else {
+          this._clearListener('click');
+          this._clearListener('dblclick');
+          this._clearListener('rightclick');
+        }
+      }
+    },
+
+    dragEventsChanged: function() {
+      if (this.map) {
+        if (this.clickEvents) {
+          this._forwardEvent('drag');
+          this._forwardEvent('dragend');
+          this._forwardEvent('dragstart');
+        } else {
+          this._clearListener('drag');
+          this._clearListener('dragend');
+          this._clearListener('dragstart');
+        }
+      }
+    },
+
+    mouseEventsChanged: function() {
+      if (this.map) {
+        if (this.clickEvents) {
+          this._forwardEvent('mousemove');
+          this._forwardEvent('mouseout');
+          this._forwardEvent('mouseover');
+        } else {
+          this._clearListener('mousemove');
+          this._clearListener('mouseout');
+          this._clearListener('mouseover');
+        }
+      }
+    },
+
     maxZoomChanged: function() {
       if (this.map) {
         this.map.setOptions({maxZoom: Number(this.maxZoom)});
@@ -814,12 +939,6 @@ Fired when the Maps API has fully loaded.
       }
     },
 
-    _addEventForwarder: function(name) {
-      google.maps.event.addListener(this.map, name, function(event) {
-        this.fire('google-map-' + name, event);
-      }.bind(this));
-    },
-
     addMapListeners: function() {
       google.maps.event.addListener(this.map, 'center_changed', function() {
         var center = this.map.getCenter();
@@ -831,18 +950,22 @@ Fired when the Maps API has fully loaded.
         this.zoom = this.map.getZoom();
       }.bind(this));
 
-      this._addEventForwarder('click');
-      this._addEventForwarder('dblclick');
-      this._addEventForwarder('drag');
-      this._addEventForwarder('dragend');
-      this._addEventForwarder('dragstart');
-      this._addEventForwarder('idle');
-      this._addEventForwarder('mousemove');
-      this._addEventForwarder('mouseout');
-      this._addEventForwarder('mouseover');
-      this._addEventForwarder('projection-changed');
-      this._addEventForwarder('rightclick');
-      this._addEventForwarder('tiles-loaded');
+      this.clickEventsChanged();
+      this.dragEventsChanged();
+      this.mouseEventsChanged();
+    },
+
+    _clearListener: function(name) {
+      if (this._listeners[name]) {
+        google.maps.event.removeListener(this._listeners[name]);
+        this._listeners[name] = null;
+      }
+    },
+
+    _forwardEvent: function(name) {
+      this._listeners[name] = google.maps.event.addListener(this.map, name, function(event) {
+        this.fire('google-map-' + name, event);
+      }.bind(this));
     }
 
   });


### PR DESCRIPTION
This adds logic to fire events for a map's mouse/touch and lifecycle events (see https://developers.google.com/maps/documentation/javascript/reference#Map).