### PR TITLE
Directions improvements

### DIFF
--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -34,14 +34,14 @@ Fired whenever the directions service returns a result.
   @param {object} detail.response The directions service response.
 -->
 
-<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode response libraries">
+<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode version response libraries">
   <template>
     <style>
       :host {
         display: none;
       }
     </style>
-    <google-maps-api apiKey="{{apiKey}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}"></google-maps-api>
+    <google-maps-api apiKey="{{apiKey}}" version="{{version}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}"></google-maps-api>
   </template>
   <script>
     Polymer({
@@ -104,6 +104,15 @@ Fired whenever the directions service returns a result.
        * @default "places"
        */
       libraries: "places",
+
+      /**
+       * Version of the Google Maps API to use.
+       *
+       * @attribute version
+       * @type string
+       * @default 3.exp
+       */
+      version: '3.exp',
 
       /**
        * The response from the directions service.

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -34,17 +34,25 @@ Fired whenever the directions service returns a result.
   @param {object} detail.response The directions service response.
 -->
 
-<polymer-element name="google-map-directions" attributes="map startAddress endAddress travelMode response libraries">
+<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode response libraries">
   <template>
     <style>
       :host {
         display: none;
       }
     </style>
-    <google-maps-api on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}"></google-maps-api>
+    <google-maps-api apiKey="{{apiKey}}" on-api-load="{{mapApiLoaded}}" libraries="{{libraries}}"></google-maps-api>
   </template>
   <script>
     Polymer({
+
+    /**
+     * A Maps API key. To obtain an API key, see developers.google.com/maps/documentation/javascript/tutorial#api_key.
+     *
+     * @property apiKey
+     * @type string
+     */
+    apiKey: null,
 
       /**
        * The Google map object.

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -49,7 +49,7 @@ Fired whenever the directions service returns a result.
       /**
        * A Maps API key. To obtain an API key, see developers.google.com/maps/documentation/javascript/tutorial#api_key.
        *
-       * @property apiKey
+       * @attribute apiKey
        * @type string
        */
       apiKey: null,
@@ -91,16 +91,7 @@ Fired whenever the directions service returns a result.
       travelMode: 'DRIVING',
 
       /**
-       * Options for rendering.
-       *
-       * @attribute rendererOptions
-       * @type object
-       * @default {}
-       */
-      rendererOptions: {},
-
-      /**
-       * A panel for displaying directions
+       * A panel for displaying directions.
        *
        * @attribute panel
        * @type HTMLElement
@@ -138,6 +129,17 @@ Fired whenever the directions service returns a result.
        * @attribute response
        * @type object
        */
+
+      created: function() {
+        /**
+         * Options for rendering.
+         *
+         * @attribute rendererOptions
+         * @type object
+         * @default {}
+         */
+        this.rendererOptions = {};
+      },
 
       observe: {
         startAddress: 'route',

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -34,7 +34,7 @@ Fired whenever the directions service returns a result.
   @param {object} detail.response The directions service response.
 -->
 
-<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode version response libraries rendererOptions">
+<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode version response libraries rendererOptions panel">
   <template>
     <style>
       :host {
@@ -100,6 +100,15 @@ Fired whenever the directions service returns a result.
       rendererOptions: {},
 
       /**
+       * A panel for displaying directions
+       *
+       * @attribute panel
+       * @type HTMLElement
+       * @default null
+       */
+      panel: null,
+
+      /**
        * A comma separated list (e.g. "places,geometry") of libraries to load
        * with this map. Defaults to "places". For more information see
        * https://developers.google.com/maps/documentation/javascript/libraries.
@@ -149,10 +158,12 @@ Fired whenever the directions service returns a result.
             this.directionsRenderer = new google.maps.DirectionsRenderer(this.rendererOptions);
           }
           this.directionsRenderer.setMap(this.map);
+          this.directionsRenderer.setPanel(this.panel);
           this.responseChanged();
         } else {
           // If there is no more map, remove the directionsRenderer from the map and delete it.
           this.directionsRenderer.setMap(null);
+          this.directionsRenderer.setPanel(null);
           this.directionsRenderer = null;
         }
       },

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -46,13 +46,13 @@ Fired whenever the directions service returns a result.
   <script>
     Polymer({
 
-    /**
-     * A Maps API key. To obtain an API key, see developers.google.com/maps/documentation/javascript/tutorial#api_key.
-     *
-     * @property apiKey
-     * @type string
-     */
-    apiKey: null,
+      /**
+       * A Maps API key. To obtain an API key, see developers.google.com/maps/documentation/javascript/tutorial#api_key.
+       *
+       * @property apiKey
+       * @type string
+       */
+      apiKey: null,
 
       /**
        * The Google map object.

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -34,7 +34,7 @@ Fired whenever the directions service returns a result.
   @param {object} detail.response The directions service response.
 -->
 
-<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode version response libraries">
+<polymer-element name="google-map-directions" attributes="apiKey map startAddress endAddress travelMode version response libraries rendererOptions">
   <template>
     <style>
       :host {
@@ -91,6 +91,15 @@ Fired whenever the directions service returns a result.
       travelMode: 'DRIVING',
 
       /**
+       * Options for rendering.
+       *
+       * @attribute rendererOptions
+       * @type object
+       * @default {}
+       */
+      rendererOptions: {},
+
+      /**
        * A comma separated list (e.g. "places,geometry") of libraries to load
        * with this map. Defaults to "places". For more information see
        * https://developers.google.com/maps/documentation/javascript/libraries.
@@ -137,7 +146,7 @@ Fired whenever the directions service returns a result.
       mapChanged: function() {
         if (this.map && this.map instanceof google.maps.Map) {
           if (!this.directionsRenderer) {
-            this.directionsRenderer = new google.maps.DirectionsRenderer();
+            this.directionsRenderer = new google.maps.DirectionsRenderer(this.rendererOptions);
           }
           this.directionsRenderer.setMap(this.map);
           this.responseChanged();


### PR DESCRIPTION
A few straightforward additions to the `directions` element. `apiKey` and `version` are already used for the `map` element so I ported them over. `rendererOptions` [accepts options for displaying the directions on a map](https://developers.google.com/maps/documentation/javascript/reference#DirectionsRendererOptions). `panel` accepts a reference to a `div` inside which the textual directions will be rendered automatically, without having to parse the `response` object.