### PR TITLE
Enable multiple results to be returned from <google-map-search>

### DIFF
--- a/google-map-search.html
+++ b/google-map-search.html
@@ -85,11 +85,8 @@ Fired when the search element returns a result.
        * If `latitude` and `longitude` are not specified,
        * the center of the currently visible map area is used.
        *
-       * Ignored if `currentMapArea` is true.
-       *
-       * @attribute radius
-       * @type number
-       * @default null
+       * If not set, search will be restricted to the currently visible
+       * map area, unless `global` is set to true.
        */
       radius: {
         type: Number,
@@ -97,13 +94,14 @@ Fired when the search element returns a result.
       },
 
       /**
-       * Restrict the search only to the current map area.
+       * By default, search is restricted to the currently visible map area.
+       * Set this to true to search everywhere.
        *
-       * @attribute currentMapArea
+       * Ignored if `radius` is set.
        */
-      currentMapArea: {
+      global: {
         type: Boolean,
-        value: true
+        value: false
       },
 
       /**
@@ -123,7 +121,7 @@ Fired when the search element returns a result.
        */
       results: {
         type: Array,
-        value: null,
+        value: function() { return []; },
         notify: true
       }
     },
@@ -135,8 +133,6 @@ Fired when the search element returns a result.
 
     /**
      * Perform a search using for `query` for the search term.
-     *
-     * @method search
      */
     search: function() {
       if (this.query && this.map) {
@@ -146,7 +142,7 @@ Fired when the search element returns a result.
           var types = this.types.split(' ');
         }
 
-        if (this.currentMapArea) {
+        if (!this.global) {
           var bounds = this.map.getBounds();
         } else if (this.radius) {
           var radius = this.radius;

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -14,13 +14,17 @@ information on the API.
 
     <template is="dom-bind">
       <google-map-search map="{{map}}" query="Pizza"
-                         result="{{result}}"></google-map-search>
+                         results="{{results}}"></google-map-search>
       <google-map map="{{map}}" latitude="37.779"
-                  longitude="-122.3892"></google-map>
-      <div>Result:
-        <span>{{result.latitude}}</span>,
-        <span>{{result.longitude}}</span>
-      </div>
+                  longitude="-122.3892">
+        <template repeat="{{results}}">
+          <google-map-marker latitude="{{latitude}}"
+                             longitude="{{longitude}}">
+            <h2>{{name}}</h2>
+            {{formatted_address}}
+          </google-map-marker>
+        </template>
+      </google-map>
     </template>
     <script>
       document.querySelector('google-map-search').search();
@@ -34,8 +38,8 @@ information on the API.
 /**
 Fired when the search element returns a result.
 
-@event google-map-search-result
-@param {Object} detail
+@event google-map-search-results
+@param {Array} detail An array of search results
   @param {number} detail.latitude Latitude of the result.
   @param {number} detail.longitude Longitude of the result.
   @param {bool} detail.show Whether to show the result on the map.
@@ -57,7 +61,10 @@ Fired when the search element returns a result.
       },
 
       /**
-       * The search result.
+       * The search results.
+       *
+       * @attribute results
+       * @type object
        */
       result: {
         type: Object,
@@ -71,7 +78,9 @@ Fired when the search element returns a result.
     ],
 
     /**
-     * Performance a search using for `query` for the search term.
+     * Perform a search using for `query` for the search term.
+     *
+     * @method search
      */
     search: function() {
       if (this.query && this.map) {
@@ -81,12 +90,14 @@ Fired when the search element returns a result.
     },
 
     _gotResults: function(results, status) {
-      this.result = {
-        latitude: results[0].geometry.location.lat(),
-        longitude: results[0].geometry.location.lng(),
-        show: true
-      }
-      this.fire('google-map-search-result', this.result);
+      this.results = results.map(function(result) {
+        // obtain lat/long from geometry
+        result.latitude  = result.geometry.location.lat();
+        result.longitude = result.geometry.location.lng();
+
+        return result;
+      });
+      this.fire('google-map-search-results', this.results);
     }
   });
 </script>

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -86,7 +86,7 @@ Fired when the search element returns a result.
        * the center of the currently visible map area is used.
        *
        * If not set, search will be restricted to the currently visible
-       * map area, unless `global` is set to true.
+       * map area, unless `globalSearch` is set to true.
        */
       radius: {
         type: Number,
@@ -99,7 +99,7 @@ Fired when the search element returns a result.
        *
        * Ignored if `radius` is set.
        */
-      global: {
+      globalSearch: {
         type: Boolean,
         value: false
       },
@@ -142,7 +142,7 @@ Fired when the search element returns a result.
           var types = this.types.split(' ');
         }
 
-        if (!this.global) {
+        if (!this.globalSearch) {
           var bounds = this.map.getBounds();
         } else if (this.radius) {
           var radius = this.radius;

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -45,6 +45,7 @@ Fired when the search element returns a result.
   @param {bool} detail.show Whether to show the result on the map.
 */
     properties: {
+
       /**
        * The Google map object.
        */
@@ -52,6 +53,7 @@ Fired when the search element returns a result.
         type: Object,
         value: null
       },
+
       /**
        * The search query.
        */
@@ -71,6 +73,18 @@ Fired when the search element returns a result.
       }
 
       /**
+       * Space-separated list of result types.
+       * The search will only return results of the listed types.
+       * See https://developers.google.com/places/documentation/supported_types
+       * for a list of supported types.
+       * Leave empty or null to search for all result types.
+       */
+      types: {
+        type: String,
+        value: null
+      } 
+
+      /**
        * The search results.
        */
       results: {
@@ -81,7 +95,7 @@ Fired when the search element returns a result.
     },
 
     observers: [
-      'search(query,map,currentMapArea)'
+      'search(query,map,types,currentMapArea)'
     ],
 
     /**
@@ -92,8 +106,12 @@ Fired when the search element returns a result.
     search: function() {
       if (this.query && this.map) {
         var places = new google.maps.places.PlacesService(this.map);
+        var types = this.types && typeof this.types == 'string' ?
+                    this.types.split(' ') : null;
+
         places.textSearch({
           query: this.query,
+          types: types,
           bounds: this.currentMapArea ? this.map.getBounds() : null
         }, this._gotResults.bind(this));
       }

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -63,6 +63,40 @@ Fired when the search element returns a result.
       },
 
       /**
+       * Latitude of the center of the search area.
+       * Ignored if `currentMapArea` is true.
+       */
+      latitude: {
+        type: Number,
+        value: null
+      },
+
+      /**
+       * Longitude of the center of the search area.
+       * Ignored if `currentMapArea` is true.
+       */
+      longitude: {
+        type: Number,
+        value: null
+      },
+
+      /**
+       * Search radius, in meters.
+       * If `latitude` and `longitude` are not specified,
+       * the center of the currently visible map area is used.
+       *
+       * Ignored if `currentMapArea` is true.
+       *
+       * @attribute radius
+       * @type number
+       * @default null
+       */
+      radius: {
+        type: Number,
+        value: null
+      },
+
+      /**
        * Restrict the search only to the current map area.
        *
        * @attribute currentMapArea
@@ -70,7 +104,7 @@ Fired when the search element returns a result.
       currentMapArea: {
         type: Boolean,
         value: true
-      }
+      },
 
       /**
        * Space-separated list of result types.
@@ -82,7 +116,7 @@ Fired when the search element returns a result.
       types: {
         type: String,
         value: null
-      } 
+      },
 
       /**
        * The search results.
@@ -95,7 +129,8 @@ Fired when the search element returns a result.
     },
 
     observers: [
-      'search(query,map,types,currentMapArea)'
+      'search(query,map,location,radius,types,currentMapArea)',
+      '_updateLocation(latitude,longitude)'
     ],
 
     /**
@@ -106,13 +141,24 @@ Fired when the search element returns a result.
     search: function() {
       if (this.query && this.map) {
         var places = new google.maps.places.PlacesService(this.map);
-        var types = this.types && typeof this.types == 'string' ?
-                    this.types.split(' ') : null;
+
+        if (this.types && typeof this.types == 'string') {
+          var types = this.types.split(' ');
+        }
+
+        if (this.currentMapArea) {
+          var bounds = this.map.getBounds();
+        } else if (this.radius) {
+          var radius = this.radius;
+          var location = this.location ? this.location : this.map.getCenter();
+        }
 
         places.textSearch({
           query: this.query,
           types: types,
-          bounds: this.currentMapArea ? this.map.getBounds() : null
+          bounds: bounds,
+          radius: radius,
+          location: location
         }, this._gotResults.bind(this));
       }
     },
@@ -126,6 +172,19 @@ Fired when the search element returns a result.
         return result;
       });
       this.fire('google-map-search-results', this.results);
+    },
+
+    _updateLocation: function() {
+      if (!this.map) {
+        return;
+      } else if (typeof this.latitude !== 'number' || isNaN(this.latitude)) {
+        throw new TypeError('latitude must be a number');
+      } else if (typeof this.longitude !== 'number' || isNaN(this.longitude)) {
+        throw new TypeError('longitude must be a number');
+      }
+
+      // Update location. This will trigger a new search.
+      this.location = new google.maps.LatLng(this.latitude, this.longitude);
     }
   });
 </script>

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -13,7 +13,7 @@ information on the API.
 #### Example:
 
     <template is="dom-bind">
-      <google-map-search map="{{map}}" query="Pizza"
+      <google-map-search map="{{map}}" query="Pizza" currentMapArea
                          results="{{results}}"></google-map-search>
       <google-map map="{{map}}" latitude="37.779"
                   longitude="-122.3892">
@@ -61,20 +61,27 @@ Fired when the search element returns a result.
       },
 
       /**
-       * The search results.
+       * Restrict the search only to the current map area.
        *
-       * @attribute results
-       * @type object
+       * @attribute currentMapArea
        */
-      result: {
-        type: Object,
+      currentMapArea: {
+        type: Boolean,
+        value: true
+      }
+
+      /**
+       * The search results.
+       */
+      results: {
+        type: Array,
         value: null,
         notify: true
       }
     },
 
     observers: [
-      'search(query,map)'
+      'search(query,map,currentMapArea)'
     ],
 
     /**
@@ -87,7 +94,7 @@ Fired when the search element returns a result.
         var places = new google.maps.places.PlacesService(this.map);
         places.textSearch({
           query: this.query,
-          bounds: this.map.getBounds()
+          bounds: this.currentMapArea ? this.map.getBounds() : null
         }, this._gotResults.bind(this));
       }
     },

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -85,7 +85,10 @@ Fired when the search element returns a result.
     search: function() {
       if (this.query && this.map) {
         var places = new google.maps.places.PlacesService(this.map);
-        places.textSearch({query: this.query}, this._gotResults.bind(this));
+        places.textSearch({
+          query: this.query,
+          bounds: this.map.getBounds()
+        }, this._gotResults.bind(this));
       }
     },
 


### PR DESCRIPTION
## Summary

This allows multiple results to be returned from `<google-map-search>` (instead of just one). This fixes #16.

## Details

This is the simplest way I could come up with to generalize the `<google-map-search>` tag for multiple results. 

The `result` property and accompanying event have been renamed to `results`, and `google-map-search-results>`, respectively. All results are processed so that they have an obvious `latitude` and `longitude` property (instead of having to obtain that information manually via `geometry`). No other post-processing is done.

The documentation, including the usage example, has been updated accordingly. The example now shows how to display the search result on the actual map using `<google-map-marker>` elements. 

## Features

- Restrict the search to the currently visible map area using the `currentMapArea` attribute
- Restrict search results to show only certain result types via the `types` attribute
- Search by location and radius (location defaults to current map center)
- Documentation and updated example included

## Known Issues

~~Even with the `map` property set, the search is currently not affected by the location shown on the map, or restricted to the map boundaries. Instead, it shows the top results world wide (I believe). I plan to address this in the next version.~~

~~There is no support for other optional settings of the `PlacesService#textSearch` function, but I'm planning to add this soon.~~

The `currentMapArea` attribute does not work if the `map` is not yet fully loaded.