### PR TITLE
Fix #137, fitToMarkers

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -383,7 +383,7 @@ The `google-map` element renders a Google Map.
 
       // do not recompute if markers have not been added or removed
       if (newMarkers.length === this.markers.length) {
-        var added = newMarkers.filter( function(m) {
+        var added = newMarkers.filter(function(m) {
             return this.markers && this.markers.indexOf(m) === -1;
           }.bind(this));
         if (added.length === 0) {
@@ -392,8 +392,6 @@ The `google-map` element renders a Google Map.
       }
 
       this.markers = newMarkers;
-      // this.markers = Array.prototype.slice.call(
-      //     Polymer.dom(this.$.markers).getDistributedNodes());
 
       // Watch for future updates.
       if (this._mutationObserver) {

--- a/google-map.html
+++ b/google-map.html
@@ -378,8 +378,22 @@ The `google-map` element renders a Google Map.
     },
 
     _updateMarkers: function() {
-      this.markers = Array.prototype.slice.call(
+      var newMarkers = Array.prototype.slice.call(
           Polymer.dom(this.$.markers).getDistributedNodes());
+
+      // do not recompute if markers have not been added or removed
+      if (newMarkers.length === this.markers.length) {
+        var added = newMarkers.filter( function(m) {
+            return this.markers && this.markers.indexOf(m) === -1;
+          }.bind(this));
+        if (added.length === 0) {
+          return;
+        }
+      }
+
+      this.markers = newMarkers;
+      // this.markers = Array.prototype.slice.call(
+      //     Polymer.dom(this.$.markers).getDistributedNodes());
 
       // Watch for future updates.
       if (this._mutationObserver) {
@@ -396,10 +410,9 @@ The `google-map` element renders a Google Map.
         for (var i = 0, m; m = this.markers[i]; ++i) {
           m.map = this.map;
         }
-
-        if (this.fitToMarkers) {
-          this._fitToMarkersChanged();
-        }
+      }
+      if (this.fitToMarkers) {
+        this._fitToMarkersChanged();
       }
     },
 
@@ -424,6 +437,9 @@ The `google-map` element renders a Google Map.
       if (this.map) {
         google.maps.event.trigger(this.map, 'resize');
         this._updateCenter();
+        if (this.fitToMarkers) { // we might not have a center if we are doing fit-to-markers
+          this._fitToMarkersChanged();
+        }
       }
     },
 


### PR DESCRIPTION
2 fixes:
- on resize(), if fitToMarkers redo _fitToMarkersChanged(). Without this, you see nothing
- do not _updateMarkers if marker list has not changed. google maps create tons
  of update events, and it feels very expensive, and prevents scrolling of fit-to-markers