### PR TITLE
Fix for #134, zoomable can't be unset

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -231,11 +231,11 @@ The `google-map` element renders a Google Map.
       },
 
       /**
-       * If false, prevent the user from zooming the map interactively.
+       * If true, prevent the user from zooming the map interactively.
        */
-      zoomable: {
+      notZoomable: {
         type: Boolean,
-        value: true,
+        value: false,
         observer: '_zoomableChanged'
       },
 
@@ -359,8 +359,8 @@ The `google-map` element renders a Google Map.
         tilt: this.noAutoTilt ? 0 : 45,
         mapTypeId: this.mapType,
         disableDefaultUI: this.disableDefaultUi,
-        disableDoubleClickZoom: !this.zoomable,
-        scrollwheel: this.zoomable,
+        disableDoubleClickZoom: this.notZoomable,
+        scrollwheel: !this.notZoomable,
         styles: this.styles,
         maxZoom: Number(this.maxZoom),
         minZoom: Number(this.minZoom)
@@ -535,8 +535,8 @@ The `google-map` element renders a Google Map.
         return;
       }
       this.map.setOptions({
-        disableDoubleClickZoom: !this.zoomable,
-        scrollwheel: this.zoomable
+        disableDoubleClickZoom: this.notZoomable,
+        scrollwheel: !this.notZoomable
       });
     },
 

--- a/google-map.html
+++ b/google-map.html
@@ -233,10 +233,10 @@ The `google-map` element renders a Google Map.
       /**
        * If true, prevent the user from zooming the map interactively.
        */
-      notZoomable: {
+      disableZoom: {
         type: Boolean,
         value: false,
-        observer: '_zoomableChanged'
+        observer: '_disableZoomChanged'
       },
 
       /**
@@ -359,8 +359,8 @@ The `google-map` element renders a Google Map.
         tilt: this.noAutoTilt ? 0 : 45,
         mapTypeId: this.mapType,
         disableDefaultUI: this.disableDefaultUi,
-        disableDoubleClickZoom: this.notZoomable,
-        scrollwheel: !this.notZoomable,
+        disableDoubleClickZoom: this.disableZoom,
+        scrollwheel: !this.disableZoom,
         styles: this.styles,
         maxZoom: Number(this.maxZoom),
         minZoom: Number(this.minZoom)
@@ -530,13 +530,13 @@ The `google-map` element renders a Google Map.
       this.map.setOptions({disableDefaultUI: this.disableDefaultUi});
     },
 
-    _zoomableChanged: function() {
+    _disableZoomChanged: function() {
       if (!this.map) {
         return;
       }
       this.map.setOptions({
-        disableDoubleClickZoom: this.notZoomable,
-        scrollwheel: !this.notZoomable
+        disableDoubleClickZoom: this.disableZoom,
+        scrollwheel: !this.disableZoom
       });
     },
 

--- a/test/google-map-basic.html
+++ b/test/google-map-basic.html
@@ -12,7 +12,7 @@
 
   <google-map id="map1"></google-map>
   <google-map id="map2" latitude="37.555" longitude="-122.555"></google-map>
-  <google-map id="map3" zoomable zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt show-center-marker fit-to-markers></google-map>
+  <google-map id="map3" not-zoomable zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt show-center-marker fit-to-markers></google-map>
 
 <script>
 var map = document.querySelector('#map1');
@@ -62,7 +62,7 @@ suite('google-map', function() {
     assert.equal(map.noAutoTilt, false);
     assert.isUndefined(map.maxZoom);
     assert.isUndefined(map.minZoom);
-    assert.isTrue(map.zoomable);
+    assert.isFalse(map.notZoomable);
     assert.equal(map.latitude, 37.77493);
     assert.equal(map.longitude, -122.41942);
     assert.equal(map.mapType, 'roadmap');
@@ -75,7 +75,7 @@ suite('google-map', function() {
       assert.equal(map3.zoom, map3.map.getZoom());
       assert.equal(map3.maxZoom, map3.map.maxZoom);
       assert.equal(map3.minZoom, map3.map.minZoom);
-      assert.isTrue(map3.zoomable);
+      assert.isTrue(map3.notZoomable);
 
       done();
     });

--- a/test/google-map-basic.html
+++ b/test/google-map-basic.html
@@ -12,7 +12,7 @@
 
   <google-map id="map1"></google-map>
   <google-map id="map2" latitude="37.555" longitude="-122.555"></google-map>
-  <google-map id="map3" not-zoomable zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt show-center-marker fit-to-markers></google-map>
+  <google-map id="map3" disable-zoom zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt show-center-marker fit-to-markers></google-map>
 
 <script>
 var map = document.querySelector('#map1');
@@ -62,7 +62,7 @@ suite('google-map', function() {
     assert.equal(map.noAutoTilt, false);
     assert.isUndefined(map.maxZoom);
     assert.isUndefined(map.minZoom);
-    assert.isFalse(map.notZoomable);
+    assert.isFalse(map.disableZoom);
     assert.equal(map.latitude, 37.77493);
     assert.equal(map.longitude, -122.41942);
     assert.equal(map.mapType, 'roadmap');
@@ -75,7 +75,7 @@ suite('google-map', function() {
       assert.equal(map3.zoom, map3.map.getZoom());
       assert.equal(map3.maxZoom, map3.map.maxZoom);
       assert.equal(map3.minZoom, map3.map.minZoom);
-      assert.isTrue(map3.notZoomable);
+      assert.isTrue(map3.disableZoom);
 
       done();
     });


### PR DESCRIPTION
There is no way to set boolean attribute that defaults to true back to false in Polymer
Fix is to rename attribute to notZoomable, and default it to false.