### PR TITLE
Two way data binding of google-map map property

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -151,14 +151,6 @@ The `google-map` element renders a Google Map.
       clientId: String,
 
       /**
-       * A Maps API object.
-       */
-      map: {
-        type: Object,
-        notify: true
-      },
-
-      /**
        * A latitude to center the map on.
        */
       latitude: {
@@ -166,6 +158,15 @@ The `google-map` element renders a Google Map.
         value: 37.77493,
         notify: true,
         reflectToAtrribute: true
+      },
+
+      /**
+       * A Maps API object.
+       */
+      map: {
+        type: Object,
+        notify: true,
+        value: null
       },
 
       /**
@@ -403,6 +404,8 @@ The `google-map` element renders a Google Map.
         var added = newMarkers.filter(function(m) {
             return this.markers && this.markers.indexOf(m) === -1;
           }.bind(this));
+
+//        debugger;
         if (added.length === 0) {
           return;
         }

--- a/google-map.html
+++ b/google-map.html
@@ -150,6 +150,14 @@ The `google-map` element renders a Google Map.
       clientId: String,
 
       /**
+       * A Maps API object.
+       */
+      map: {
+        type: Object,
+        notify: true
+      },
+
+      /**
        * A latitude to center the map on.
        */
       latitude: {


### PR DESCRIPTION
`google-map-search` element gives the following example:

```
    <template is="dom-bind">
      <google-map-search map="{{map}}" query="Pizza"
                         result="{{result}}"></google-map-search>
      <google-map map="{{map}}" latitude="37.779"
                  longitude="-122.3892"></google-map>
      <div>Result:
        <span>{{result.latitude}}</span>,
        <span>{{result.longitude}}</span>
      </div>
    </template>
    <script>
      document.querySelector('google-map-search').search();
    < /script>
```

However, two way data binding in this case will fail, as google-map has not enabled `notify: true` 