### PR TITLE
Import directions and search so that they appear in the docs dropdown

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -4,6 +4,8 @@
 <link rel="import" href="../google-apis/google-maps-api.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="google-map-marker.html">
+<link rel="import" href="google-map-directions.html">
+<link rel="import" href="google-map-search.html">
 <!--
 The `google-map` element renders a Google Map.
 


### PR DESCRIPTION
Currently on this page (https://googlewebcomponents.github.io/google-map/components/google-map/), the top left drop-down does not display the links to the documentation of google-map-search and google-map-directions. This pull request fixes this problem (see image below).

![screen shot 2015-07-07 at 16 02 25](https://cloud.githubusercontent.com/assets/2418026/8547823/bb6fc466-24c1-11e5-81ee-63aa7c3c5948.png)