### PR TITLE
FIX for Issue 185.

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -65,7 +65,7 @@ The `google-map` element renders a Google Map.
 
   </style>
   <template>
-    <google-maps-api
+    <google-maps-api id="api"
       api-key="[[apiKey]]"
       client-id="[[clientId]]"
       version="[[version]]"
@@ -371,7 +371,7 @@ The `google-map` element renders a Google Map.
       if (this.map) {
         return; // already initialized
       }
-      if (!(window.google && window.google.maps)) {
+      if (this.$.api.libraryLoaded !== true) {
         return; // api not loaded
       }
       if (!this.isAttached) {


### PR DESCRIPTION
Per discussion from issue https://github.com/GoogleWebComponents/google-map/issues/185. This fixes a minor race-condition. But it would be worth investigating why google.maps.Map can be undefined when google.maps isn't just to make sure there isn't anything else going on.