### PR TITLE
added ability to define kml URL as <google-map ... kml='url'>

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -195,7 +195,7 @@ The `google-map` element renders a Google Map.
       kml: {
         type: String,
         value: null,
-	observer: '_loadKml'
+        observer: '_loadKml'
       },
 
       /**

--- a/google-map.html
+++ b/google-map.html
@@ -194,7 +194,8 @@ The `google-map` element renders a Google Map.
        */
       kml: {
         type: String,
-        value: null
+        value: null,
+	observer: '_loadKml'
       },
 
       /**

--- a/google-map.html
+++ b/google-map.html
@@ -190,6 +190,14 @@ The `google-map` element renders a Google Map.
       },
 
       /**
+       * A kml file to load.
+       */
+      kml: {
+        type: String,
+        value: null
+      },
+
+      /**
        * A zoom level to set the map to.
        */
       zoom: {
@@ -381,6 +389,7 @@ The `google-map` element renders a Google Map.
       this.map = new google.maps.Map(this.$.map, this._getMapOptions());
       this._listeners = {};
       this._updateCenter();
+      this._loadKml();
       this._updateMarkers();
       this._addMapListeners();
       this.fire('google-map-ready');
@@ -489,6 +498,15 @@ The `google-map` element renders a Google Map.
         if (this.fitToMarkers) { // we might not have a center if we are doing fit-to-markers
           this._fitToMarkersChanged();
         }
+      }
+    },
+
+    _loadKml: function() {
+      if (this.kml) {
+        var kmlfile = new google.maps.KmlLayer({
+          url: this.kml,
+          map: this.map
+        });
       }
     },
 


### PR DESCRIPTION
Rather than using an event listener for 'google-map-ready' I added the ability to define a KML url inline:
<google-map id="map" latitude="{{base.lat}}" longitude="{{base.lon}}" language="en" fit-to-markers  kml="http://host.org/file.kml">
