### PR TITLE
Prevent fitToMarkers centering without markers

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -645,7 +645,7 @@ The `google-map` element renders a Google Map.
     _fitToMarkersChanged: function() {
       // TODO(ericbidelman): respect user's zoom level.
 
-      if (this.map && this.fitToMarkers) {
+      if (this.map && this.fitToMarkers && this.markers.length > 0) {
         var latLngBounds = new google.maps.LatLngBounds();
         for (var i = 0, m; m = this.markers[i]; ++i) {
           latLngBounds.extend(


### PR DESCRIPTION
https://github.com/GoogleWebComponents/google-map/issues/192#issuecomment-136191663

On resize with fitToMarkers enabled, the map was centering to the
default Latitude/Longitude returned by google.maps.LatLngBounds() if no
markers existed. This change prevents this by verifying that the markers
array has at least one element before centering.