### PR TITLE
Attribute to automatically close other infowindows when new one is opened

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "polymer": "Polymer/polymer#^1.1.4",
     "google-apis": "GoogleWebComponents/google-apis#^1.1.1",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0"
-    "iron-selector": "PolymerElements/iron-selector#^1.0.0"
+    "iron-selector": "PolymerElements/iron-selector#^1.0.2"
   },
   "devDependencies": {
     "web-component-tester": "*",

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "polymer": "Polymer/polymer#^1.1.4",
     "google-apis": "GoogleWebComponents/google-apis#^1.1.1",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0"
+    "iron-selector": "PolymerElements/iron-selector#^1.0.0"
   },
   "devDependencies": {
     "web-component-tester": "*",

--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -114,14 +114,17 @@ child of `google-map`.
      * @event google-map-marker-rightclick
      * @param {google.maps.MouseEvent} event The mouse event.
      */
+
     /**
      * Fired when an infowindow is opened.
      * @event google-map-marker-open
      */
+
     /**
      * Fired when the close button of the infowindow is pressed.
      * @event google-map-marker-close
-     */ 
+     */
+
     properties: {
       /**
        * A Google Maps marker object.
@@ -238,6 +241,8 @@ child of `google-map`.
       if (this.marker) {
         this.marker.setMap(this.map);
       }
+      if (this.open)
+        this.fire('google-map-marker-open');
     },
 
     _updatePosition: function() {

--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -114,7 +114,14 @@ child of `google-map`.
      * @event google-map-marker-rightclick
      * @param {google.maps.MouseEvent} event The mouse event.
      */
-
+    /**
+     * Fired when an infowindow is opened.
+     * @event google-map-marker-open
+     */
+    /**
+     * Fired when the close button of the infowindow is pressed.
+     * @event google-map-marker-close
+     */ 
     properties: {
       /**
        * A Google Maps marker object.
@@ -202,6 +209,15 @@ child of `google-map`.
         type: String,
         value: null,
         observer: '_animationChanged'
+      },
+
+      /**
+       * Specifies whether the InfoWindow is open or not
+       */
+      open: {
+        type: Boolean,
+        value: false,
+        observer: '_openChanged'
       }
     },
 
@@ -222,6 +238,8 @@ child of `google-map`.
       if (this.marker) {
         this.marker.setMap(this.map);
       }
+      if (this.open)
+        this.fire('google-map-marker-open');
     },
 
     _updatePosition: function() {
@@ -310,16 +328,31 @@ child of `google-map`.
         if (!this.info) {
           // Create a new infowindow
           this.info = new google.maps.InfoWindow();
-          this.infoHandler_ = google.maps.event.addListener(this.marker, 'click', function() {
-            this.info.open(this.map, this.marker);
+          this.openInfoHandler_ = google.maps.event.addListener(this.marker, 'click', function() {
+            this.fire('google-map-marker-open');
+          }.bind(this));
+          
+          this.closeInfoHandler_ = google.maps.event.addListener(this.info, 'closeclick', function() {
+            this.fire('google-map-marker-close');
           }.bind(this));
         }
         this.info.setContent(content);
       } else {
         if (this.info) {
           // Destroy the existing infowindow.  It doesn't make sense to have an empty one.
-          google.maps.event.removeListener(this.infoHandler_);
+          google.maps.event.removeListener(this.openInfoHandler_);
+          google.maps.event.removeListener(this.closeInfoHandler_);
           this.info = null;
+        }
+      }
+    },
+
+    _openChanged: function() {
+      if (this.info) {
+        if (this.open) {
+          this.info.open(this.map, this.marker);
+        } else {
+          this.info.close();
         }
       }
     },
@@ -343,6 +376,7 @@ child of `google-map`.
       this._clickEventsChanged();
       this._contentChanged();
       this._mouseEventsChanged();
+      this._openChanged();
       setupDragHandler_.bind(this)();
     },
 

--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -238,8 +238,6 @@ child of `google-map`.
       if (this.marker) {
         this.marker.setMap(this.map);
       }
-      if (this.open)
-        this.fire('google-map-marker-open');
     },
 
     _updatePosition: function() {
@@ -329,11 +327,11 @@ child of `google-map`.
           // Create a new infowindow
           this.info = new google.maps.InfoWindow();
           this.openInfoHandler_ = google.maps.event.addListener(this.marker, 'click', function() {
-            this.fire('google-map-marker-open');
+            this.open = true;
           }.bind(this));
           
           this.closeInfoHandler_ = google.maps.event.addListener(this.info, 'closeclick', function() {
-            this.fire('google-map-marker-close');
+            this.open = false;
           }.bind(this));
         }
         this.info.setContent(content);
@@ -351,8 +349,10 @@ child of `google-map`.
       if (this.info) {
         if (this.open) {
           this.info.open(this.map, this.marker);
+          this.fire('google-map-marker-open');
         } else {
           this.info.close();
+          this.fire('google-map-marker-close');
         }
       }
     },

--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -241,8 +241,6 @@ child of `google-map`.
       if (this.marker) {
         this.marker.setMap(this.map);
       }
-      if (this.open)
-        this.fire('google-map-marker-open');
     },
 
     _updatePosition: function() {

--- a/google-map.html
+++ b/google-map.html
@@ -431,7 +431,7 @@ The `google-map` element renders a Google Map.
         return;
       }
       this._mutationObserver = new MutationObserver( this._updateMarkers.bind(this));
-      this._mutationObserver.observe(this, {
+      this._mutationObserver.observe(this.$.selector, {
         childList: true
       });
     },

--- a/google-map.html
+++ b/google-map.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../google-apis/google-maps-api.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="google-map-marker.html">
 <!--
 The `google-map` element renders a Google Map.
@@ -74,8 +75,9 @@ The `google-map` element renders a Google Map.
       on-api-load="_mapApiLoaded"></google-maps-api>
 
     <div id="map"></div>
-
-    <content id="markers" select="google-map-marker"></content>
+    <iron-selector id="selector" multi="[[!singleInfoWindow]]" selected-attribute="open" activate-event="google-map-marker-open" on-google-map-marker-close="_deselectMarker">
+      <content id="markers" select="google-map-marker"></content>
+    </iron-selector>
 
   </template>
 </dom-module>
@@ -340,8 +342,15 @@ The `google-map` element renders a Google Map.
         type: Array,
         value: function() { return []; },
         readOnly: true
-      }
+      },
 
+      /**
+       * If set, all other info windows on markers are closed when opening a new one.
+       */
+      singleInfoWindow: {
+        type: Boolean,
+        value: false
+      }
     },
 
     behaviors: [
@@ -683,7 +692,20 @@ The `google-map` element renders a Google Map.
       this._listeners[name] = google.maps.event.addListener(this.map, name, function(event) {
         this.fire('google-map-' + name, event);
       }.bind(this));
-    }
+    },
+
+   _deselectMarker: function(e) { 
+     // If singleInfoWindow is set, update core-selector's selected attribute to be null.
+     // Else remvoe the marker from core-selector's selected array.
+     var markerSelector = this.$.selector;
+     var markerIndex = markerSelector.items.indexOf(e.target);
+
+     if (this.singleInfoWindow) {
+      markerSelector.selected = null;
+     } else {
+      markerSelector.selectedValues = markerSelector.selectedValues.filter(function(i) {return i != markerIndex});
+     }
+   }
 
   });
 

--- a/google-map.html
+++ b/google-map.html
@@ -694,16 +694,15 @@ The `google-map` element renders a Google Map.
       }.bind(this));
     },
 
-   _deselectMarker: function(e) { 
-     // If singleInfoWindow is set, update core-selector's selected attribute to be null.
-     // Else remove the marker from core-selector's selected array.
-     var markerSelector = this.$.selector;
-     var markerIndex = markerSelector.items.indexOf(e.target);
+   _deselectMarker: function(e, detail) { 
+     // If singleInfoWindow is set, update iron-selector's selected attribute to be null.
+     // Else remove the marker from iron-selector's selected array.
+     var markerIndex = this.$.selector.indexOf(e.target);
 
      if (this.singleInfoWindow) {
-      markerSelector.selected = null;
+      this.$.selector.selected = null;
      } else {
-      markerSelector.selectedValues = markerSelector.selectedValues.filter(function(i) {return i !== markerIndex});
+      this.$.selector.selectedValues = this.$.selector.selectedValues.filter(function(i) {return i !== markerIndex});
      }
    }
 

--- a/google-map.html
+++ b/google-map.html
@@ -696,7 +696,7 @@ The `google-map` element renders a Google Map.
 
    _deselectMarker: function(e) { 
      // If singleInfoWindow is set, update core-selector's selected attribute to be null.
-     // Else remvoe the marker from core-selector's selected array.
+     // Else remove the marker from core-selector's selected array.
      var markerSelector = this.$.selector;
      var markerIndex = markerSelector.items.indexOf(e.target);
 

--- a/google-map.html
+++ b/google-map.html
@@ -703,7 +703,7 @@ The `google-map` element renders a Google Map.
      if (this.singleInfoWindow) {
       markerSelector.selected = null;
      } else {
-      markerSelector.selectedValues = markerSelector.selectedValues.filter(function(i) {return i != markerIndex});
+      markerSelector.selectedValues = markerSelector.selectedValues.filter(function(i) {return i !== markerIndex});
      }
    }
 

--- a/test/google-map-basic.html
+++ b/test/google-map-basic.html
@@ -12,7 +12,7 @@
 
   <google-map id="map1"></google-map>
   <google-map id="map2" latitude="37.555" longitude="-122.555"></google-map>
-  <google-map id="map3" disable-zoom zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt fit-to-markers></google-map>
+  <google-map id="map3" disable-zoom zoom="11" min-zoom="10" max-zoom="11" no-auto-tilt fit-to-markers single-info-window></google-map>
 
   <div id='newmap'>
   </div>
@@ -65,6 +65,7 @@ suite('google-map', function() {
     assert.isUndefined(map.maxZoom);
     assert.isUndefined(map.minZoom);
     assert.isFalse(map.disableZoom);
+    assert.isFalse(map.singleInfoWindow);
     assert.equal(map.latitude, 37.77493);
     assert.equal(map.longitude, -122.41942);
     assert.equal(map.mapType, 'roadmap');
@@ -78,6 +79,7 @@ suite('google-map', function() {
       assert.equal(map3.maxZoom, map3.map.maxZoom);
       assert.equal(map3.minZoom, map3.map.minZoom);
       assert.isTrue(map3.disableZoom);
+      assert.isTrue(map3.singleInfoWindow);
 
       done();
     });

--- a/test/marker-basic.html
+++ b/test/marker-basic.html
@@ -44,6 +44,7 @@ suite('markers', function() {
     assert.equal(markerEl.zIndex, 0);
     assert.equal(markerEl.latitude, 37.779);
     assert.equal(markerEl.longitude, -122.3892);
+    assert.isFalse(markerEl.open);
     assert.isNull(markerEl.offsetParent,
                   'google-map-marker should be display: none');
   });


### PR DESCRIPTION
The `single-info-window` attribute allows to close all other infowindows when a new one is opened. Also, the `<google-map-marker>` now has an attribute `open` which allows to open infowindows declaratively.

It should be noted that because of the way `<iron-selector>` handles selection the infowindow closing behavior has changed a little. Now, if the attribute is _not_ set, users are able to close the infowindow by reclicking on the marker. This is because `<iron-selector>` deselects elements if their activation event fires again _and_ the multi attribute is set. The code is cleaner this way but I could also implement the selection of markers myself (instead of using `<iron-selector>`'s `activate-event` attribute) if this is a big deal.

What do you guys think?