### PR TITLE
notify changes to zoom and maptype (fresh PR)

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -204,7 +204,8 @@ The `google-map` element renders a Google Map.
       zoom: {
         type: Number,
         value: 10,
-        observer: '_zoomChanged'
+        observer: '_zoomChanged',
+        notify: true
       },
 
       /**
@@ -221,7 +222,8 @@ The `google-map` element renders a Google Map.
       mapType: {
         type: String,
         value: 'roadmap', // roadmap, satellite, hybrid, terrain,
-        observer: '_mapTypeChanged'
+        observer: '_mapTypeChanged',
+        notify: true
       },
 
       /**
@@ -670,6 +672,10 @@ The `google-map` element renders a Google Map.
 
       google.maps.event.addListener(this.map, 'zoom_changed', function() {
         this.zoom = this.map.getZoom();
+      }.bind(this));
+      
+      google.maps.event.addListener(this.map, 'maptypeid_changed', function() {
+        this.mapType = this.map.getMapTypeId();
       }.bind(this));
 
       this._clickEventsChanged();


### PR DESCRIPTION
@ebidel 

Reopening #170 from @jshortall, which got mixed up with another commit in that PR.

Regarding the concerns in that thread: the Maps API will happily fire `zoom_changed` and `maptypeid_changed` even when they don't change, but Polymer only notifies or triggers observers on those values if the value has actually changed, preventing an infinite loop of notifications.

Regarding https://github.com/GoogleWebComponents/google-map/pull/170#issuecomment-116037060, I want to bind to zoom to change styling on the map based on zoom, so that's at least two people who want it bindable :)