### PR TITLE
remove `libraries` from properties due to new defaults

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,10 +22,8 @@
 </head>
 <body fullbleed>
 
-<!-- Note: places library needs to be loaded because we're using google-map-directions
-     which also loads the maps lib with the places library. -->
 <google-map latitude="37.779" longitude="-122.3892" min-zoom="9" max-zoom="11"
-            language="en" libraries="places">
+            language="en">
   <google-map-marker latitude="37.779" longitude="-122.3892"
                      title="Go Giants!" draggable="true">
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/San_Francisco_Giants_Cap_Insignia.svg/200px-San_Francisco_Giants_Cap_Insignia.svg.png" />

--- a/google-map-directions.html
+++ b/google-map-directions.html
@@ -33,7 +33,6 @@ information on the API.
   <template>
     <google-maps-api
       api-key="[[apiKey]]"
-      libraries="[[libraries]]"
       language="[[language]]"
       on-api-load="_mapApiLoaded"></google-maps-api>
   </template>
@@ -108,20 +107,6 @@ Fired whenever the directions service returns a result.
          type: Array,
          value: function() { return []; }
        },
-
-      /**
-       * A comma separated list (e.g. "places,geometry") of libraries to load
-       * with this map. Defaults to "places". For more information see
-       * https://developers.google.com/maps/documentation/javascript/libraries.
-       *
-       * Note, this needs to be set to the same value as the one used on <google-map>.
-       * If you're overriding that element's `libraries` property, this one also
-       * needs to be set to the Maps API loads the library code.
-       */
-      libraries: {
-        type: String,
-        value: 'places'
-      },
 
       /**
        * The localized language to load the Maps API with. For more information

--- a/google-map-search.html
+++ b/google-map-search.html
@@ -11,8 +11,8 @@ information on the API.
 #### Example:
 
     <template is="dom-bind">
-      <google-map-search map="[[map]]" libraries="places" query="Pizza"
-                         results="{{results}}"></google-map-search>
+      <google-map-search map="[[map]]" query="Pizza" results="{{results}}">
+      </google-map-search>
       <google-map map="{{map}}" latitude="37.779"
                   longitude="-122.3892">
         <template is="dom-repeat" items="{{results}}" as="marker">

--- a/google-map.html
+++ b/google-map.html
@@ -38,7 +38,7 @@ The `google-map` element renders a Google Map.
 
 <b>Example</b> - with Google directions, using data-binding inside another Polymer element
 
-    <google-map map="{{map}}" libraries="places"></google-map>
+    <google-map map="{{map}}"></google-map>
     <google-map-directions map="{{map}}"
         start-address="San Francisco" end-address="Mountain View">
     </google-map-directions>
@@ -69,7 +69,6 @@ The `google-map` element renders a Google Map.
       api-key="[[apiKey]]"
       client-id="[[clientId]]"
       version="[[version]]"
-      libraries="[[libraries]]"
       signed-in="[[signedIn]]"
       language="[[language]]"
       on-api-load="_mapApiLoaded"></google-maps-api>
@@ -167,16 +166,6 @@ The `google-map` element renders a Google Map.
         type: Object,
         notify: true,
         value: null
-      },
-
-      /**
-       * A comma separated list (e.g. "places,geometry") of libraries to load
-       * with this map. Defaults to "". For more information see
-       * https://developers.google.com/maps/documentation/javascript/libraries.
-       */
-      libraries: {
-        type: String,
-        value: ''
       },
 
       /**


### PR DESCRIPTION
In anticipation of landing https://github.com/GoogleWebComponents/google-apis/pull/58, remove `libraries` from all the `google-map-*` components. All existing code will continue to work as setting `libraries` will now just be a no-op.

For compatibility, we'll probably have to update the `google-apis` requirement in `bower.json`. When that lands I can add that to this commit or someone can rev separately.