### PR TITLE
Add draggable=false note to google-map docs

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -44,6 +44,8 @@ The `google-map` element renders a Google Map.
         start-address="San Francisco" end-address="Mountain View">
     </google-map-directions>
 
+<b>Note</b> You can disable dragging by adding `draggable="false"` on the `google-map` element.
+
 @demo demo/index.html
 @demo demo/polys.html
 @demo demo/kml.html


### PR DESCRIPTION
As `draggable` is not a property on the Polymer element (but is supported by the element), it is not mentioned in the properties documentation. Since `draggable="false"` is required to stop the map from capturing scroll events on for example a mobile page, add a note that mentions that you can disable dragging.