### PR TITLE
Use items-changed event ILO MutationObserver for markers (issue 299)

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -144,7 +144,7 @@ The `google-map` element renders a Google Map.
      * @event google-map-rightclick
      * @param {google.maps.MouseEvent} event The mouse event.
      */
-    /** 
+    /**
      * Fired when the map becomes idle after panning or zooming.
      * @event google-map-idle
     */
@@ -407,8 +407,9 @@ The `google-map` element renders a Google Map.
 
     detached: function() {
       if (this._mutationObserver) {
-        this._mutationObserver.disconnect();
+        this.unlisten(this.$.selector, 'items-changed', '_updateMarkers');
         this._mutationObserver = null;
+
       }
       if (this._objectsMutationObserver) {
         this._objectsMutationObserver.disconnect();
@@ -480,10 +481,7 @@ The `google-map` element renders a Google Map.
       if (this._mutationObserver) {
         return;
       }
-      this._mutationObserver = new MutationObserver(this._updateMarkers.bind(this));
-      this._mutationObserver.observe(this.$.selector, {
-        childList: true
-      });
+      this._mutationObserver = this.listen(this.$.selector, 'items-changed', '_updateMarkers');
     },
 
     _updateMarkers: function() {
@@ -630,7 +628,7 @@ The `google-map` element renders a Google Map.
         this.map.setZoom(Number(this.zoom));
       }
     },
-    
+
     _idleEvent: function() {
       if (this.map) {
         this._forwardEvent('idle');

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
         'google-map-update-pos.html',
         'marker-basic.html',
         'markers-add-remove.html',
+        'markers-add-remove.html?dom=shadow',
         'poly-basic.html'
       ]);
     </script>


### PR DESCRIPTION
… issue [#299](https://github.com/GoogleWebComponents/google-map/issues/299) ...

The MutationObserver works in shady dom but not in shadow dom because it is observing a shadow dom element (iron-selector.#selector). Mutation events cannot pierce the shadow dom (there is even a test for this in chromium - [MutationObserver / shadow-dom.html](https://chromium.googlesource.com/chromium/blink/+/6db8410315ac3ad9a6f5ddd46b3d699a29744e7c/LayoutTests/fast/dom/MutationObserver/shadow-dom.html) ).

Instead, we can use the iron-selector items property and a change listener.
This also allows us to include the markers-add-remove.html test in both shadow (where it previously failed) and shady.