### PR TITLE
Fix issue 299 MutationObserver for markers in Shadow DOM

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -144,7 +144,7 @@ The `google-map` element renders a Google Map.
      * @event google-map-rightclick
      * @param {google.maps.MouseEvent} event The mouse event.
      */
-    /** 
+    /**
      * Fired when the map becomes idle after panning or zooming.
      * @event google-map-idle
     */
@@ -407,7 +407,7 @@ The `google-map` element renders a Google Map.
 
     detached: function() {
       if (this._mutationObserver) {
-        this._mutationObserver.disconnect();
+        this.unlisten(this.$.selector, 'items-changed', '_updateMarkers');
         this._mutationObserver = null;
       }
       if (this._objectsMutationObserver) {
@@ -480,10 +480,7 @@ The `google-map` element renders a Google Map.
       if (this._mutationObserver) {
         return;
       }
-      this._mutationObserver = new MutationObserver(this._updateMarkers.bind(this));
-      this._mutationObserver.observe(this.$.selector, {
-        childList: true
-      });
+      this._mutationObserver = this.listen(this.$.selector, 'items-changed', '_updateMarkers');
     },
 
     _updateMarkers: function() {
@@ -630,7 +627,7 @@ The `google-map` element renders a Google Map.
         this.map.setZoom(Number(this.zoom));
       }
     },
-    
+
     _idleEvent: function() {
       if (this.map) {
         this._forwardEvent('idle');

--- a/google-map.html
+++ b/google-map.html
@@ -406,9 +406,9 @@ The `google-map` element renders a Google Map.
     },
 
     detached: function() {
-      if (this._mutationObserver) {
+      if (this._markersChildrenListener) {
         this.unlisten(this.$.selector, 'items-changed', '_updateMarkers');
-        this._mutationObserver = null;
+        this._markersChildrenListener = null;
       }
       if (this._objectsMutationObserver) {
         this._objectsMutationObserver.disconnect();
@@ -477,10 +477,10 @@ The `google-map` element renders a Google Map.
     // watch for future updates to marker objects
     _observeMarkers: function() {
       // Watch for future updates.
-      if (this._mutationObserver) {
+      if (this._markersChildrenListener) {
         return;
       }
-      this._mutationObserver = this.listen(this.$.selector, 'items-changed', '_updateMarkers');
+      this._markersChildrenListener = this.listen(this.$.selector, 'items-changed', '_updateMarkers');
     },
 
     _updateMarkers: function() {
@@ -494,7 +494,7 @@ The `google-map` element renders a Google Map.
         }.bind(this));
         if (added.length === 0) {
           // set up observer first time around
-          if (!this._mutationObserver) {
+          if (!this._markersChildrenListener) {
             this._observeMarkers();
           }
           return;

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
         'google-map-update-pos.html',
         'marker-basic.html',
         'markers-add-remove.html',
+        'markers-add-remove.html?dom=shadow',
         'poly-basic.html'
       ]);
     </script>

--- a/test/markers-add-remove.html
+++ b/test/markers-add-remove.html
@@ -18,7 +18,7 @@
 <script>
 var map = document.querySelector('#map1');
 
-suite('markers', function() {
+suite(`markers${Polymer.Settings.useShadow ? ' (shadow dom)' : ' (shady dom)'}`, function() {
 
   test('markers are defined, added, removed', function(done) {
     map.addEventListener('google-map-ready', function(e) {


### PR DESCRIPTION
In issue [#299](https://github.com/GoogleWebComponents/google-map/issues/299) it is observed that changes to the google-map-marker collection are not picked up by the google-map under Shadow dom as they are under Shady dom.  The code uses a MutationObserver to look for changes, but the content is inside an iron-selector:

```
<iron-selector id="selector" multi="[[!singleInfoWindow]]" selected-attribute="open" activate-event="google-map-marker-open" on-google-map-marker-close="_deselectMarker">
      <content id="markers" select="google-map-marker"></content>
    </iron-selector>
    <content id="objects" select="*"></content>

this._mutationObserver = new MutationObserver(this._updateMarkers.bind(this));
this._mutationObserver.observe(this.$.selector, {
  childList: true
});
```
That makes content#markers light dom to the iron-selector, but shadow/shady dom to google-map. Mutation events do not bubble to the outside from within shadow dom. There is even a test for this in the Chromium project - [LayoutTests/fast/dom/MutationObserver/shadow-dom.html](https://chromium.googlesource.com/chromium/blink/+/6db8410315ac3ad9a6f5ddd46b3d699a29744e7c/LayoutTests/fast/dom/MutationObserver/shadow-dom.html).

In any case, iron-selector is already observing changes to content#markers.  In this PR the google-map is modified to listen for changes to the items property of iron-selector#selector instead of using a MutationObserver.

The existing test, markers-add-remove.html, illustrates both the issue and this fix. With the fix we can add the dom=shadow variety of this test to the list of suites to run.
