### PR TITLE
fix map not showing up when first initialized without a height

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -69,7 +69,7 @@ If you're seeing the message "You have included the Google Maps API multiple tim
     }
 
     #map {
-      position: absolute;
+      position: absolute !important;
       top: 0;
       right: 0;
       bottom: 0;


### PR DESCRIPTION
When the map is initialized and the element has no height (`clientHeight=0`), e.g. when one of the parents are not yet attached, the map will never show up. This is because google maps adds a `position: relative` to the style of the map element. Calling, the notifyResize will not help in this case. Forcing absolute position, fixes this problem (notifyResize is still needed).
