### PR TITLE
this.markers is set to readyOnly: true in the properties. this.marker…

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -554,7 +554,7 @@ If you're seeing the message "You have included the Google Maps API multiple tim
 
         this._observeMarkers();
 
-        this.markers = this._setMarkers(newMarkers);
+        this._setMarkers(newMarkers);
 
         // Set the map on each marker and zoom viewport to ensure they're in view.
         this._attachChildrenToMap(this.markers);


### PR DESCRIPTION
Fixes issue #353

markers property is set to readOnly and will throw an error if set directly.
`this.markers = VALUE` is incorrect.
`this._setMarkers(VALUE)` is correct. 
Currently it is doing both and will fail in a strict mode.