### PR TITLE
Issues with Dom-repeat and Map Markers

### DIFF
--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -394,7 +394,8 @@ child of `google-map`.
           this._contentObserver = new MutationObserver( this._contentChanged.bind(this));
           this._contentObserver.observe( this, {
             childList: true,
-            subtree: true
+            subtree: true,
+            characterData: true
           });
 
           var content = this.innerHTML.trim();

--- a/google-map.html
+++ b/google-map.html
@@ -531,7 +531,7 @@ If you're seeing the message "You have included the Google Maps API multiple tim
         if (this._markersChildrenListener) {
           return;
         }
-        this._markersChildrenListener = this.listen(this.$.selector, 'items-changed', '_updateMarkers');
+        this._markersChildrenListener = this.listen(this.$.selector, 'iron-items-changed', '_updateMarkers');
       },
 
       _updateMarkers: function() {


### PR DESCRIPTION
I was unable to get the data binding to work when using google-map-markers inside dom-repeat template.
Made 2 changes to the code to enable dynamic updating of google map markers and their contents.
The following code now works well to render markers on google map when bound to an items array.

<google-map map="{{map}}" api-key=xxxx latitude="[[lat]]" longitude="[[lon]]">
        <template is="dom-repeat" items="[[array]]">
          <google-map-marker map="[[map]]" latitude="[[item.lat]]" longitude="[[item.lon]]" title="[[item.title]]" >[[item.content]]</google-map-marker>
        </template>
      </google-map>


Possible issues resolved #299 #319 #297 #288 #263 