### PR TITLE
Added the `loading` property to `google-map-search`.

### DIFF
--- a/google-map-search.html
+++ b/google-map-search.html
@@ -104,6 +104,20 @@ information on the API.
       },
 
       /**
+       * Whether or not the search is in progress.
+       * This is set to true when the search begins and it is set to false when it completes.
+       * This will be updated to false before `google-map-search-results` is fired.
+       *
+       * When this is false, `results` has been set and is available.
+       */
+      loading: {
+        type: Boolean,
+        value: false,
+        notify: true,
+        readOnly: true
+      },
+
+      /**
        * The search results.
        */
       results: {
@@ -157,6 +171,7 @@ information on the API.
         } else if (!this.globalSearch) {
           var bounds = this.map.getBounds();
         }
+        this._setLoading( true );
         places.textSearch({
           query: this.query,
           types: types,
@@ -195,6 +210,7 @@ information on the API.
         result.longitude = result.geometry.location.lng();
         return result;
       });
+      this._setLoading( false );
       this.fire('google-map-search-results', this.results);
     },
 

--- a/test/google-map-search.html
+++ b/test/google-map-search.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../google-map.html">
+  <link rel="import" href="../google-map-search.html">
+</head>
+<body>
+
+  <google-map id="map" api-key="YOUR_KEY_HERE"></google-map>
+  <google-map-search id="search"></google-map-search>
+
+<script>
+var map = document.querySelector('#map');
+var search = document.querySelector('#search');
+
+suite('google-map-search', function() {
+  // Ensure that the defaults are as expected.
+  test('defaults', function() {
+    assert.isFalse(search.globalSearch);
+    assert.isNull(search.latitude);
+    assert.isFalse(search.loading);
+    assert.isNull(search.location);
+    assert.isNull(search.longitude);
+    assert.isNull(search.query);
+    assert.isNull(search.radius);
+    assert.equal(search.results.length, 0);
+    assert.isNull(search.types);
+  });
+
+  // Ensure that the search action behaves properly.
+  test('search', function(done) {
+    // This is the number of times that the `loading` property changed.
+    var loadingChanges = 0;
+    // This is called when the `loading` property changes.
+    // We'll use this to increment `loadingChanges`.
+    search.addEventListener('loading-changed', function(e) {
+      loadingChanges++;
+    });
+    // This is called when the search query completes.
+    // This will conclude our test.
+    search.addEventListener('google-map-search-results', function(e) {
+      // When this event fires, `loading` should be false.
+      assert.isFalse(search.loading);
+      // Loading changes:
+      // 1. false -> true
+      // 2. true -> false
+      assert.equals(loadingChanges,2);
+
+      done();
+    });
+
+    // This is called when the `google-map` is ready.
+    // We are going to start a search by updating the `query` property.
+    map.addEventListener('google-map-ready', function(e) {
+      // Set the `map` property on the `google-map-search`.
+      search.map = map.map;
+      // Begin a search.
+      search.query = "221B Baker Street";
+    });
+  });
+
+});
+
+</script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@
       WCT.loadSuites([
         'google-map-basic.html',
         'google-map-update-pos.html',
+        'google-map-search.html',
         'marker-basic.html',
         'markers-add-remove.html',
         'markers-add-remove.html?dom=shadow',


### PR DESCRIPTION
I try to minimize the amount of Javascript that my elements need to function, and the lack
of a `loading` property on `google-map-search` forced me to do a lot more event handling than
I would have liked.  So, I added one.

Essentially, `loading` defaults to false.  It is set to true in the `search` method, and it
is set to false once again in the `_gotResults` method.  It is updated before `google-map-search-results`
is fired, so that event will properly occur once all search actions are complete.

I also added a unit test around searching.  I noticed that most of the tests won't run properly
without an `api-key` set on the `google-map`, so I guess that we'll all just have to insert our
own during testing?  Kinda strange.

Anyway, this will now let you easily notify your users that a search is in progress.  Previously,
this had to be done with a lot more hooks and events.

```
<google-map-search map="[[map]]" results="{{results}}" loading="{{loading}}"></google-map-search>

<template is="dom-if" if="[[loading]]">
  Loading...
</template>
<template is="dom-if" if="[[!loading]]">
  <ul>
  <template is="dom-repeat" items="[[results]]">
    <li>[[item.formatted_address]]</li>
  </template>
  </ul>
</template>
```