### PR TITLE
Change icon type from Object to String

### DIFF
--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -207,8 +207,8 @@ child of `google-map`.
            * @type string|google.maps.Icon|google.maps.Symbol
            */
           icon: {
-            type: Object,
-            value: null,
+            type: String,
+            value: '',
             observer: '_iconChanged'
           },
 


### PR DESCRIPTION
Allow to use google-map-marker with icon parameter passed as a string

<google-map-marker icon="/assets/icon.svg"></google-map-marker>

Before change you cant use string directly into tag attribute, you had to pass it as a bind property, like so:

<google-map-marker icon="{{ icon }}"></google-map-marker>