### PR TITLE
adding extra checking in _clearListener method

### DIFF
--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -458,7 +458,7 @@ child of `google-map`.
         },
 
         _clearListener: function(name) {
-          if (this._listeners[name]) {
+          if (this._listeners && this._listeners[name]) {
             google.maps.event.removeListener(this._listeners[name]);
             this._listeners[name] = null;
           }


### PR DESCRIPTION
When I using google map component with marker component multiple times on different pages, it makes error like this: 
![image](https://user-images.githubusercontent.com/19873442/30967517-35c4e488-a465-11e7-8107-1701618fc1f2.png)

So, it solves a trouble.