### PR TITLE
Fix click error due to undefined listener object

### DIFF
--- a/google-map-marker.html
+++ b/google-map-marker.html
@@ -467,13 +467,14 @@ child of `google-map`.
         },
 
         _clearListener: function(name) {
-          if (this._listeners[name]) {
+          if (this._listeners && this._listeners[name]) {
             google.maps.event.removeListener(this._listeners[name]);
             this._listeners[name] = null;
           }
         },
 
         _forwardEvent: function(name) {
+          this._listeners = this.listeners || {};
           this._listeners[name] = google.maps.event.addListener(this.marker, name, function(event) {
             this.fire('google-map-marker-' + name, event);
           }.bind(this));


### PR DESCRIPTION
Checking if listeners is defined before accessing property and removing. Before setting new properties set empty object if it is undefined.

This is also noted in issue #407 . But does not include setting new listeners