### PR TITLE
fix google-map _updateMarkers to set markers property correctly

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -557,7 +557,7 @@ If you're seeing the message "You have included the Google Maps API multiple tim
 
           this._observeMarkers();
 
-          this.markers = this._setMarkers(newMarkers);
+          this._setMarkers(newMarkers);
 
           // Set the map on each marker and zoom viewport to ensure they're in view.
           this._attachChildrenToMap(this.markers);


### PR DESCRIPTION
This pull request probably fixes a number of issues related to markers.  The _updateMarkers method in google-map is not setting the markers property correctly.  I believe the following commit is to blame: be0881eba858f64bf87b8fe8a2770e86da07fb87.  In addition, your documentation needs to be updated to specify that markers need to have attribute slot="markers" in order to be added to the markers property.