### PR TITLE
<google-map-poly>: Fully specify LatLng type name.

### DIFF
--- a/google-map-poly.html
+++ b/google-map-poly.html
@@ -49,7 +49,7 @@ child of `google-map` and will contain at least two `google-map-point` child ele
          * initially or when they are changed.
          *
          * @event google-map-poly-path-built
-         * @param {google.maps.MVCArray.<LatLng>} path The poly path.
+         * @param {google.maps.MVCArray.<google.maps.LatLng>} path The poly path.
          */
 
         /**
@@ -57,7 +57,7 @@ child of `google-map` and will contain at least two `google-map-point` child ele
          * provided path to rebuild its list of points.
          *
          * @event google-map-poly-path-updated
-         * @param {google.maps.MVCArray.<LatLng>} path The poly path.
+         * @param {google.maps.MVCArray.<google.maps.LatLng>} path The poly path.
          */
 
         /**
@@ -159,7 +159,7 @@ child of `google-map` and will contain at least two `google-map-point` child ele
           /**
            * An array of the Google Maps LatLng objects that define the poly shape.
            *
-           * @type google.maps.MVCArray.<LatLng>
+           * @type google.maps.MVCArray.<google.maps.LatLng>
            */
           path: {
             type: Object,


### PR DESCRIPTION
In google-map-poly.html, the LatLng type name was incorrectly specified
without its namespace, leaving it technically as an unmatched type
at the top level.  This properly qualifies the name.