### PR TITLE
add global styles in the shadow root

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -455,6 +455,7 @@ If you're seeing the message "You have included the Google Maps API multiple tim
         ],
 
         attached: function() {
+          this._observeHeadMutation();
           this._initGMap();
         },
 
@@ -467,6 +468,23 @@ If you're seeing the message "You have included the Google Maps API multiple tim
             this._objectsMutationObserver.disconnect();
             this._objectsMutationObserver = null;
           }
+        },
+
+        _observeHeadMutation: function() {
+          const observer = new MutationObserver((mutationsList) => {
+            for(const mutation of mutationsList) {
+              for (const node of mutation.addedNodes) {
+                if(node.nodeName === 'STYLE' && node.textContent.indexOf('gm-') !== -1){
+                  this._copyToShadowRoot(node);
+                }
+              }
+            }
+          });
+          observer.observe(document.head, { childList: true });
+        },
+
+        _copyToShadowRoot: function(node){
+          this.shadowRoot.appendChild(node.cloneNode(true));
         },
 
         _initGMap: function() {


### PR DESCRIPTION
The main reason why the styles are failing is because the styles for google map are added in the head of the document where google map api is called.
The `this.$.map` is defined in the shadow-root where the styles are encapsulated, therefore the styles are not applied.

When google maps api changed from version 3.34 to 3.35, they added 2 more img tags for each buttons and the global styles were suppose to handle the overlay.

The one way to fix this is to copy the style nodes into the shadow root of the `google-map` web component.

I added a mutation observer when the web component has been attached to observe the head of the document. When the style node that contains the text `gm-` is added then the node gets copied the shadow root.

This should also fix other problems that arises that depends on global styles.

Resolves #435 and #423 and other issues that arises from global styles not cascading down into shadow-root.